### PR TITLE
Fix for AdjustToColor for colors with sub-1 brightness and saturation

### DIFF
--- a/ChromaColorPicker/ChromaColorPicker.swift
+++ b/ChromaColorPicker/ChromaColorPicker.swift
@@ -153,19 +153,20 @@ open class ChromaColorPicker: UIControl {
         let newColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: alpha)
         
         /* Set the slider value for the new color and update addButton */
-        shadeSlider.primaryColor = UIColor(hue: hue, saturation: 1, brightness: 1, alpha: 1) //Set a color recognzied on the color wheel
+        shadeSlider.primaryColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1) //Set a color recognzied on the color wheel
         
         /* Update the angle and currentColor */
         currentAngle = angleForColor(newColor)
         currentColor = newColor
-        
-        if brightness < 1.0 { //currentValue is on the left side of the slider
+        if brightness < 1.0 && saturation < 1.0 {
+            shadeSlider.currentValue = 0
+        } else if brightness < 1.0 { //currentValue is on the left side of the slider
             shadeSlider.currentValue = brightness-1
         }else{
             shadeSlider.currentValue = -(saturation-1)
         }
         shadeSlider.updateHandleLocation() //update the handle location now that the value is set
-        addButton.color = shadeSlider.currentColor
+        addButton.color = newColor
         
         /* Will layout based on new angle */
         self.layoutHandle()

--- a/ChromaColorPicker/ChromaColorPicker.swift
+++ b/ChromaColorPicker/ChromaColorPicker.swift
@@ -153,12 +153,14 @@ open class ChromaColorPicker: UIControl {
         let newColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: alpha)
         
         /* Set the slider value for the new color and update addButton */
-        shadeSlider.primaryColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1) //Set a color recognzied on the color wheel
+        shadeSlider.primaryColor = UIColor(hue: hue, saturation: 1, brightness: 1, alpha: 1) //Set a color recognzied on the color wheel
         
         /* Update the angle and currentColor */
         currentAngle = angleForColor(newColor)
         currentColor = newColor
         if brightness < 1.0 && saturation < 1.0 {
+            /* Modifies the Shade Slider to handle adjusting to colors outside of the Chroma scope */
+            shadeSlider.primaryColor = UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1)
             shadeSlider.currentValue = 0
         } else if brightness < 1.0 { //currentValue is on the left side of the slider
             shadeSlider.currentValue = brightness-1


### PR DESCRIPTION
Hey @joncardasis,
I went through a made a few small changes, all within the adjustToColor function to handle what seemed to be the source of the Bug. When a color had a reduced saturation and brightness the color slider would not properly adjust, as you had code in there to prevent colors not on the wheel from appearing, thus returning the wrong color.  So I changed that code so If the color had both values below one then the shade slider would accept a gradient with the new values placing the current one in the center of the bar. To return to normal functionality all you need to do is try and adjust to a different hue and your code would handle the rest.
Also I wasn't sure what you meant when you said the ShadeSlider was based on Saturation as from what I saw the slider middle value of the slider denotes the difference between reducing brightness or saturation.
I ran some tests with a variety of brightnesses and saturations and couldn't find any distinct bugs.
Sorry If this was longwinded, I'm new to working on Open Source projects. Please let me know if there's any problems with the code, or if you have another reason for not wanting to pull it (like detracting from the original design).