### PR TITLE
Update to Swift 5, add Accio support & make more customizable

### DIFF
--- a/ChromaColorPicker-Demo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ChromaColorPicker-Demo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ChromaColorPicker/ChromaAddButton.swift
+++ b/ChromaColorPicker/ChromaAddButton.swift
@@ -37,11 +37,14 @@ open class ChromaAddButton: UIButton {
         didSet{
             self.layoutCircleLayer()
             self.layoutPlusIconLayer()
+            self.layoutCustomImageLayer()
         }
     }
     open var circleLayer: CAShapeLayer?
     open var plusIconLayer: CAShapeLayer?
-    
+    open var customImageLayer: CALayer?
+    open var userContentMode: UIView.ContentMode = .scaleAspectFit
+    open var userImage: UIImage?
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
@@ -90,5 +93,37 @@ open class ChromaAddButton: UIButton {
             layer.lineWidth = frame.width * 0.03
         }
     }
-    
+
+    open func setCustomImage(_ image: UIImage?) {
+        let imageView = UIImageView(frame: self.circleLayer!.frame)
+        if let image = image {
+            userImage = image
+        }
+        imageView.image = userImage
+        imageView.contentMode = self.userContentMode
+
+        customImageLayer?.removeFromSuperlayer()
+        customImageLayer = imageView.layer
+        guard let customImageLayer = customImageLayer else {
+            return
+        }
+        self.layoutCustomImageLayer()
+        plusIconLayer?.removeFromSuperlayer()
+        self.layer.addSublayer(customImageLayer)
+    }
+
+    open func layoutCustomImageLayer() {
+        if let layer = customImageLayer {
+            layer.frame = self.bounds
+            layer.frame.origin.x = 3
+            layer.frame.origin.y = 5
+            layer.frame.size.width -= 10
+            layer.frame.size.height -= 10
+        }
+    }
+
+    open func setContentMode(contentMode: UIView.ContentMode) {
+        self.userContentMode = contentMode
+        self.setCustomImage(nil)
+    }
 }

--- a/ChromaColorPicker/ChromaColorPicker.swift
+++ b/ChromaColorPicker/ChromaColorPicker.swift
@@ -146,6 +146,10 @@ open class ChromaColorPicker: UIControl {
         shadeSlider.primaryColor = currentColor
         self.updateHexLabel() //update for hex value
     }
+
+    open func customImageForAddButton(_ image: UIImage) {
+        self.addButton.setCustomImage(image)
+    }
     
     open func adjustToColor(_ color: UIColor){
         /* Apply saturation and brightness from previous color to current one */

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "ChromaColorPicker",
+    // platforms: [.iOS("8.0")],
+    products: [
+        .library(name: "ChromaColorPicker", targets: ["ChromaColorPicker"])
+    ],
+    targets: [
+        .target(
+            name: "ChromaColorPicker",
+            path: "ChromaColorPicker"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Some changes you can look forward to are:
 github "joncardasis/ChromaColorPicker"
 ```
 
+### Accio
+
+```swift
+.package(url: "https://github.com/valerianb/ChromaColorPicker.git", .upToNextMajor(from: "1.7.0")),
+```
+
+Next, add `ChromaColorPicker` to your App targets dependencies like so:
+
+```swift
+.target(name: "App", dependencies: ["ChromaColorPicker"]),
+```
+
 ### Cocoapods
 ```
 pod 'ChromaColorPicker'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Platform](https://img.shields.io/badge/platform-iOS-lightgray.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Carthage](https://img.shields.io/badge/Carthage-✔-green.svg)
+![Accio](https://img.shields.io/badge/Accio-✔-green.svg)
 ![CocoaPods](https://img.shields.io/badge/CocoaPods-1.7.2-green.svg)
 
 *An intuitive iOS color picker built in Swift.*


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Also this is based on @valerianb fork, therefore adds Swift 5 support. (#37)

Additionally, this adds more customization options added by @jamitJona [here](https://github.com/jamitJona/ChromaColorPicker/commit/54259bb5b42db98fcf8a6912eca0d3391bc31018).