### PR TITLE
Bump swift-tools-version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 


### PR DESCRIPTION
SPM package resolve failed due to old tool version. This leads to error during build process and impossible use via SPM.